### PR TITLE
hiding progress view from super view to allow user interactions

### DIFF
--- a/Example/UCZProgressView/DetailViewController.m
+++ b/Example/UCZProgressView/DetailViewController.m
@@ -52,11 +52,15 @@
     if ([[NSUserDefaults standardUserDefaults] objectForKey:@"textFontSize"]) {
         self.progressView.textSize = [[NSUserDefaults standardUserDefaults] doubleForKey:@"textFontSize"];
     }
+    
+    UITapGestureRecognizer *singleTap = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(didTapImage:)];
+    [self.imageView setUserInteractionEnabled:YES];
+    [self.imageView addGestureRecognizer:singleTap];
 }
 
 - (void)viewDidAppear:(BOOL)animated {
     [super viewDidAppear:animated];
-    [NSURLConnection connectionWithRequest:[NSURLRequest requestWithURL:self.fullResolutionImageURL] delegate:self];
+    [self loadImage];
 }
 
 #pragma mark -
@@ -88,6 +92,19 @@
 
 - (void)connection:(NSURLConnection *)connection didFailWithError:(NSError *)error {
     self.progressView.progress = 1.0;
+}
+
+#pragma mark - actions
+
+- (void)didTapImage:(id)sender {
+    NSLog(@"reloading progress view");
+    [self loadImage];
+}
+
+#pragma mark - private methods
+
+- (void)loadImage {
+    [NSURLConnection connectionWithRequest:[NSURLRequest requestWithURL:self.fullResolutionImageURL] delegate:self];
 }
 
 @end

--- a/Lib/UCZProgressView.m
+++ b/Lib/UCZProgressView.m
@@ -210,7 +210,7 @@
     }
     _indeterminate = indeterminate;
     
-    self.backgroundView.hidden = NO;
+    self.hidden = NO;
     
     if (indeterminate) {
         _progressLayer.strokeStart = 0.1;
@@ -258,7 +258,7 @@
     }
     
     if (progress > 0.0) {
-        self.backgroundView.hidden = NO;
+        self.hidden = NO;
     }
     
     self.progressLayer.actions = animated ? nil : @{@"strokeEnd": [NSNull null]};
@@ -324,7 +324,7 @@
 
 - (void)animationDidStop:(CAAnimation *)anim finished:(BOOL)flag {
     self.backgroundView.layer.mask = nil;
-    self.backgroundView.hidden = YES;
+    self.hidden = YES;
 }
 
 #pragma mark -


### PR DESCRIPTION
This change removes the progress view from its superview after its final animation has completed. This is needed so that users can interact with views that are underneath the progress view.